### PR TITLE
htaccess for automatic language selection

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,13 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine on
+  # no RewriteCond => unconditionally rewritten
+  # If /de or /de/anything is requested, serve /, /anything.
+  # No further rule processing! (no / -> /en redirect)
+  RewriteRule ^de(.*)$ /$1 [END]
+
+  # NC => case insensitive regexp match ("nocase")
+  RewriteCond %{HTTP:Accept-Language} !^de [NC]
+  # L => last rule, no further processing
+  # R=302 => redirect, HTTP 302
+  RewriteRule ^$ /en [L,R=302]
+</IfModule>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -9,7 +9,7 @@ format: blog-index
         {% if page.is_default_language %}
         <a rel="alternate" href="/en" hreflang="en" lang="en">English</a>
         {% else %}
-        <a rel="alternate" href="/" hreflang="de" lang="de">Deutsch</a>
+        <a rel="alternate" href="/de" hreflang="de" lang="de">Deutsch</a>
         {% endif %}
       </nav>
       <article>


### PR DESCRIPTION
What happens with Apache now:
(Accept-Language is part of the request header, xx means "anything")

```
GET /   (Accept-Language: de*) => / (as before)
GET /   (Accept-Language: xx)  => /en (redirect HTTP 302)
GET /en (Accept-Language: xx)  => /en
GET /de (Accept-Language: xx)  => /de, served from / (as before)
```

The last case is necessary to allow retrieving the German site even when
de_\* is in Accept-Language. Without that first rule, you are always
redirected to /en.)

Tested locally using this Dockerfile:
https://gist.github.com/srenatus/1aa611633b07bb2e40a7
