### PR TITLE
Fix 404 page

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,5 @@
+ErrorDocument 404 /404.html
+
 <IfModule mod_rewrite.c>
   RewriteEngine on
   # no RewriteCond => unconditionally rewritten

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ For Production, use following command and file
 
 ```jekyll serve --config _config.yml```
 
+To build the static files for production, use `jekyll build`.
+
+#### Build for staging environment
+
+For building static files for `staging.support.refugeesemancipation.com`, use
+
+```
+jekyll build --config _config.yml,_config_staging-env.yml
+```
+
+#### Build for development environment
+
+For building static files for `dev.support.refugeesemancipation.com`, use
+
+```
+jekyll build --config _config.yml,_config_dev_-env.yml
+```
+
+
 
 ## How to Contribute
 1. Fork the repository. If you don't know how to do that, [follow these instructions](https://help.github.com/articles/fork-a-repo/)

--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ description: "Refugees Emancipation Supporters Campaign #resp15"
 
 # This URL is the main adresse. Don't include a slash at the end.
 #
-url: ""
+url: "http://support.refugeesemancipation.com"
 baseurl: ""
 
 # This is for the editing function in _/includes/improve_content.html

--- a/_config_dev-env.yml
+++ b/_config_dev-env.yml
@@ -1,0 +1,1 @@
+url: "http://dev.support.refugeesemancipation.com"

--- a/_config_staging-env.yml
+++ b/_config_staging-env.yml
@@ -1,0 +1,1 @@
+url: "http://staging.support.refugeesemancipation.com"

--- a/pages/404.md
+++ b/pages/404.md
@@ -2,6 +2,7 @@
 layout: page
 title: "Oops! Nothing here..."
 subheadline: "404"
+show_meta: false
 teaser: "Maybe the webpage moved or we deleted it. Or did you maybe mistype the URL?"
 permalink: "/404.html"
 ---


### PR DESCRIPTION
- Let apache know where it is (via .htaccess)
- Remove reference to blog archive (show_meta => meta_information.html)
- Set `url` in _config.yml

The last point may need attention for staging/dev environments, but it
seemed reasonable to set it: it makes the google search function work,
too.
