### PR TITLE
Fix latest merge accident

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -74,9 +74,8 @@ format: blog-index
 <div class="row t30">
   <div class="medium-12 columns">
 
-    <h2 id="refugees-emancipation-chaos-communication-camp-2015">{{ page.video2.title }}</h2>
     <article itemprop="video" itemscope itemtype="http://schema.org/VideoObject">
-      <h2 class="video-title" id="refugees-emancipation-auf-dem-chaos-communication-camp-2015">Refugees Emancipation auf dem Chaos Communication Camp 2015</h2>
+      <h2 class="video-title" id="refugees-emancipation-chaos-communication-camp-2015">{{ page.video2.title }}</h2>
       <div id="camp2015" class="flex-video widescreen vimeo">
         test
       </div>


### PR DESCRIPTION
Accidentally, I merged the wrong video headline into master. It has to
be in the article, not above it.
