### PR TITLE
CSS code clean-up in footer

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -15,7 +15,7 @@
 
 // Container of scroll to top arrow
 #up-to-top {
-  padding: 10px 0 10px 0 !important;
+  padding: 10px 0 !important;
 }
 
 // Language toggle button
@@ -92,6 +92,10 @@
 #footer {
   padding-top: 0 !important;
   padding-bottom: 0 !important;
+
+  p > a {
+    color: inherit;
+  }
 }
 
 // Subfooter
@@ -104,6 +108,10 @@
 
   #subfooter-right {
     margin-top: 1.0625rem !important;
+    
+    p > a {
+      color: inherit;
+    }
   }
 
   @media only screen and (min-width: 40.063em) {
@@ -111,9 +119,4 @@
       margin-top: 0 !important;
     }
   }
-}
-
-//Mail footer
-#footer p a {
-  color: #fff;
 }


### PR DESCRIPTION
- Delete duplicate values in padding shorthand code
- Move anchor styles into #footer to comply with cascading coding
  convention
- Replace static text color for the ‚inherit‘ attribute, in order to
  always match with the parent text color.
