### PR TITLE
I18n nav

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -119,9 +119,11 @@
                       {% if dropdown_link.url contains 'http' %}
                         {% assign domain = '' %}
                         {% assign target = 'target="_blank"' %}
+                        {% assign lang = '' %}
                       {% else %}
                         {% assign domain = site.url %}
                         {% assign target = '' %}
+                        {% assign lang = page.language %}
                       {% endif %}
 
                       <li><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -22,7 +22,7 @@
         {% for link in site.data.navigation %}
 
               {% if link.url contains 'http' %}
-                {% assign target = 'target="_blank"' %}
+                {% assign target = ' target="_blank"' %}
                 {% capture href %}{{ link.url }}{% endcapture %}
               {% elsif link.url == '#' %}
                 {% assign target = '' %}
@@ -37,7 +37,7 @@
             {% comment %}   If right side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
               <li class="divider"></li>
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ link.url }}" {{ target }}>{{ link.title | i18n }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ href }}"{{ target }}>{{ link.title | i18n }}</a></li>
 
             {% comment %}   If right side WITH dropdown menu do   {% endcomment %}
             {% else %}
@@ -50,14 +50,14 @@
                     {% for dropdown_link in link.dropdown %}
 
                       {% if dropdown_link.url contains 'http' %}
-                        {% assign target = 'target="_blank"' %}
+                        {% assign target = ' target="_blank"' %}
                         {% capture href %}{{ link.url }}{% endcapture %}
                       {% else %}
                         {% assign target = '' %}
                         {% capture href %}{{ site.url }}{{ site.baseurl }}/{{ page.language }}{{ link.url }}{% endcapture %}
                       {% endif %}
 
-                      <li><a href="{{ href }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
+                      <li><a href="{{ href }}"{{ target }}>{{ dropdown_link.title | i18n }}</a></li>
                     {% endfor %}
                   </ul>
 
@@ -81,7 +81,7 @@
         {% for link in site.data.navigation %}
 
               {% if link.url contains 'http' %}
-                {% assign target = 'target="_blank"' %}
+                {% assign target = ' target="_blank"' %}
                 {% capture href %}{{ link.url }}{% endcapture %}
               {% elsif link.url == '#' %}
                 {% assign target = '' %}
@@ -96,7 +96,7 @@
 
             {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ href }}" {{ target }}>{{ link.title | i18n }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ href }}"{{ target }}>{{ link.title | i18n }}</a></li>
               <li class="divider"></li>
 
             {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
@@ -109,14 +109,14 @@
                     {% for dropdown_link in link.dropdown %}
 
                       {% if dropdown_link.url contains 'http' %}
-                        {% assign target = 'target="_blank"' %}
+                        {% assign target = ' target="_blank"' %}
                         {% capture href %}{{ link.url }}{% endcapture %}
                       {% else %}
                         {% assign target = '' %}
                         {% capture href %}{{ site.url }}{{ site.baseurl }}/{{ page.language }}{{ link.url }}{% endcapture %}
                       {% endif %}
 
-                      <li><a href="{{ href }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
+                      <li><a href="{{ href }}"{{ target }}>{{ dropdown_link.title | i18n }}</a></li>
                     {% endfor %}
                   </ul>
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -23,10 +23,13 @@
 
               {% if link.url contains 'http' %}
                 {% assign domain = '' %}
+                {% assign target = 'target="_blank"' %}
               {% elsif link.url == '#' %}
                 {% assign domain = '' %}
+                {% assign target = '' %}
               {% else %}
                 {% assign domain = site.url %}
+                {% assign target = '' %}
               {% endif %}
 
           {% comment %}   If there are links for right side begin   {% endcomment %}
@@ -34,25 +37,27 @@
             {% comment %}   If right side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
               <li class="divider"></li>
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ link.url }}" {{ target }}>{{ link.title }}</a></li>
 
             {% comment %}   If right side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="divider"></li>
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{{ link.url }}" {{ target }}>{{ link.title }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
 
                       {% if dropdown_link.url contains 'http' %}
                         {% assign domain = '' %}
-                        {% else %}
+                        {% assign target = 'target="_blank"' %}
+                      {% else %}
                         {% assign domain = site.url %}
+                        {% assign target = '' %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title }}</a></li>
                     {% endfor %}
                   </ul>
 
@@ -77,10 +82,13 @@
 
               {% if link.url contains 'http' %}
                 {% assign domain = '' %}
+                {% assign target = 'target="_blank"' %}
               {% elsif link.url == '#' %}
                 {% assign domain = '' %}
+                {% assign target = '' %}
               {% else %}
                 {% assign domain = site.url %}
+                {% assign target = '' %}
               {% endif %}
 
           {% comment %}   If there are links for left side begin   {% endcomment %}
@@ -88,25 +96,27 @@
 
             {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{{ target }}>{{ link.title }}</a></li>
               <li class="divider"></li>
 
             {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{{ target }}>{{ link.title }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
 
                       {% if dropdown_link.url contains 'http' %}
                         {% assign domain = '' %}
-                        {% else %}
+                        {% assign target = 'target="_blank"' %}
+                      {% else %}
                         {% assign domain = site.url %}
+                        {% assign target = '' %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title }}</a></li>
                     {% endfor %}
                   </ul>
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -37,14 +37,14 @@
             {% comment %}   If right side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
               <li class="divider"></li>
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}" {{ target }}>{{ link.title }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}" {{ target }}>{{ link.title | i18n }}</a></li>
 
             {% comment %}   If right side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="divider"></li>
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}" {{ target }}>{{ link.title }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}" {{ target }}>{{ link.title | i18n }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -57,7 +57,7 @@
                         {% assign target = '' %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
                     {% endfor %}
                   </ul>
 
@@ -96,14 +96,14 @@
 
             {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}"{{ target }}>{{ link.title }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}"{{ target }}>{{ link.title | i18n }}</a></li>
               <li class="divider"></li>
 
             {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}"{{ target }}>{{ link.title }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}"{{ target }}>{{ link.title | i18n }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -116,7 +116,7 @@
                         {% assign target = '' %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
                     {% endfor %}
                   </ul>
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -37,14 +37,14 @@
             {% comment %}   If right side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
               <li class="divider"></li>
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ link.url }}" {{ target }}>{{ link.title }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}" {{ target }}>{{ link.title }}</a></li>
 
             {% comment %}   If right side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="divider"></li>
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ link.url }}" {{ target }}>{{ link.title }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}" {{ target }}>{{ link.title }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -57,7 +57,7 @@
                         {% assign target = '' %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title }}</a></li>
                     {% endfor %}
                   </ul>
 
@@ -96,14 +96,14 @@
 
             {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{{ target }}>{{ link.title }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}"{{ target }}>{{ link.title }}</a></li>
               <li class="divider"></li>
 
             {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{{ target }}>{{ link.title }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}"{{ target }}>{{ link.title }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -116,7 +116,7 @@
                         {% assign target = '' %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title }}</a></li>
                     {% endfor %}
                   </ul>
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -24,12 +24,15 @@
               {% if link.url contains 'http' %}
                 {% assign domain = '' %}
                 {% assign target = 'target="_blank"' %}
+                {% assign lang = '' %}
               {% elsif link.url == '#' %}
                 {% assign domain = '' %}
                 {% assign target = '' %}
+                {% assign lang = '' %}
               {% else %}
                 {% assign domain = site.url %}
                 {% assign target = '' %}
+                {% assign lang = page.language %}
               {% endif %}
 
           {% comment %}   If there are links for right side begin   {% endcomment %}
@@ -37,27 +40,29 @@
             {% comment %}   If right side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
               <li class="divider"></li>
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}" {{ target }}>{{ link.title | i18n }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ link.url }}" {{ target }}>{{ link.title | i18n }}</a></li>
 
             {% comment %}   If right side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="divider"></li>
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}" {{ target }}>{{ link.title | i18n }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ link.url }}" {{ target }}>{{ link.title | i18n }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
 
                       {% if dropdown_link.url contains 'http' %}
                         {% assign domain = '' %}
+                        {% assign lang = '' %}
                         {% assign target = 'target="_blank"' %}
                       {% else %}
                         {% assign domain = site.url %}
+                        {% assign lang = page.language %}
                         {% assign target = '' %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
                     {% endfor %}
                   </ul>
 
@@ -83,12 +88,15 @@
               {% if link.url contains 'http' %}
                 {% assign domain = '' %}
                 {% assign target = 'target="_blank"' %}
+                {% assign lang = '' %}
               {% elsif link.url == '#' %}
                 {% assign domain = '' %}
                 {% assign target = '' %}
+                {% assign lang = '' %}
               {% else %}
                 {% assign domain = site.url %}
                 {% assign target = '' %}
+                {% assign lang = page.language %}
               {% endif %}
 
           {% comment %}   If there are links for left side begin   {% endcomment %}
@@ -96,14 +104,14 @@
 
             {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}"{{ target }}>{{ link.title | i18n }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ link.url }}"{{ target }}>{{ link.title | i18n }}</a></li>
               <li class="divider"></li>
 
             {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ link.url }}"{{ target }}>{{ link.title | i18n }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ link.url }}"{{ target }}>{{ link.title | i18n }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -116,7 +124,7 @@
                         {% assign target = '' %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ page.language }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
                     {% endfor %}
                   </ul>
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -22,17 +22,14 @@
         {% for link in site.data.navigation %}
 
               {% if link.url contains 'http' %}
-                {% assign domain = '' %}
                 {% assign target = 'target="_blank"' %}
-                {% assign lang = '' %}
+                {% capture href %}{{ link.url }}{% endcapture %}
               {% elsif link.url == '#' %}
-                {% assign domain = '' %}
                 {% assign target = '' %}
-                {% assign lang = '' %}
+                {% capture href %}#{% endcapture %}
               {% else %}
-                {% assign domain = site.url %}
                 {% assign target = '' %}
-                {% assign lang = page.language %}
+                {% capture href %}{{ site.url }}{{ site.baseurl }}/{{ page.language }}{{ link.url }}{% endcapture %}
               {% endif %}
 
           {% comment %}   If there are links for right side begin   {% endcomment %}
@@ -53,16 +50,14 @@
                     {% for dropdown_link in link.dropdown %}
 
                       {% if dropdown_link.url contains 'http' %}
-                        {% assign domain = '' %}
-                        {% assign lang = '' %}
                         {% assign target = 'target="_blank"' %}
+                        {% capture href %}{{ link.url }}{% endcapture %}
                       {% else %}
-                        {% assign domain = site.url %}
-                        {% assign lang = page.language %}
                         {% assign target = '' %}
+                        {% capture href %}{{ site.url }}{{ site.baseurl }}/{{ page.language }}{{ link.url }}{% endcapture %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
+                      <li><a href="{{ href }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
                     {% endfor %}
                   </ul>
 
@@ -86,17 +81,14 @@
         {% for link in site.data.navigation %}
 
               {% if link.url contains 'http' %}
-                {% assign domain = '' %}
                 {% assign target = 'target="_blank"' %}
-                {% assign lang = '' %}
+                {% capture href %}{{ link.url }}{% endcapture %}
               {% elsif link.url == '#' %}
-                {% assign domain = '' %}
                 {% assign target = '' %}
-                {% assign lang = '' %}
+                {% capture href %}#{% endcapture %}
               {% else %}
-                {% assign domain = site.url %}
                 {% assign target = '' %}
-                {% assign lang = page.language %}
+                {% capture href %}{{ site.url }}{{ site.baseurl }}/{{ page.language }}{{ link.url }}{% endcapture %}
               {% endif %}
 
           {% comment %}   If there are links for left side begin   {% endcomment %}
@@ -104,29 +96,27 @@
 
             {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ link.url }}"{{ target }}>{{ link.title | i18n }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ href }}" {{ target }}>{{ link.title | i18n }}</a></li>
               <li class="divider"></li>
 
             {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ link.url }}"{{ target }}>{{ link.title | i18n }}</a>
+                <a href="{{ href }}"{{ target }}>{{ link.title | i18n }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
 
                       {% if dropdown_link.url contains 'http' %}
-                        {% assign domain = '' %}
                         {% assign target = 'target="_blank"' %}
-                        {% assign lang = '' %}
+                        {% capture href %}{{ link.url }}{% endcapture %}
                       {% else %}
-                        {% assign domain = site.url %}
                         {% assign target = '' %}
-                        {% assign lang = page.language %}
+                        {% capture href %}{{ site.url }}{{ site.baseurl }}/{{ page.language }}{{ link.url }}{% endcapture %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ lang }}{{ dropdown_link.url }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
+                      <li><a href="{{ href }}" {{ target }}>{{ dropdown_link.title | i18n }}</a></li>
                     {% endfor %}
                   </ul>
 

--- a/_plugins/lang_filter.rb
+++ b/_plugins/lang_filter.rb
@@ -3,7 +3,11 @@ module Jekyll
   module LangFilter
     def i18n(thing)
       lang = @context.registers[:page]['language']
-      thing[lang] || thing
+      if thing.is_a?(Hash) && thing.has_key?(lang)
+        thing[lang]
+      else
+        thing
+      end
     end
   end
 end

--- a/_plugins/lang_filter.rb
+++ b/_plugins/lang_filter.rb
@@ -1,0 +1,11 @@
+
+module Jekyll
+  module LangFilter
+    def i18n(thing)
+      lang = @context.registers[:page]['language']
+      thing[lang] || thing
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::LangFilter)


### PR DESCRIPTION
- Add's `/de/` and `/en/` to the navigation links
- Figures out the link title using a Jekyll filter as follows:

```
- title: Foo
```

`{{ site.data.navigation.link.title | i18n }}` will be "Foo" for both languages,

```
- title:
    en: Foo
    de: Bar
```

`{{ site.data.navigation.link.title | i18n }}` will be Foo for English, Bar for German.
