### PR TITLE
Improve dev setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,13 @@ source "https://rubygems.org"
 
 gem 'jekyll', '2.5.3'
 gem 'jekyll-multiple-languages'
-gem 'rack-rewrite'
-gem 'sinatra'
+
+group :dev do
+  gem 'rack-rewrite', '~> 1.5.1'
+  gem 'rack-livereload', '~> 0.3.16'
+  gem 'sinatra', '~> 1.4.6'
+  gem 'guard', '~> 2.13.0'
+  gem 'guard-livereload', '~> 2.4', require: false
+  gem 'guard-jekyll-plus', '~> 2.0.2'
+  gem 'thin'
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard 'jekyll-plus', serve: true, port: 4000, config: ['_config_dev.yml'] do
+guard 'jekyll-plus', serve: true, config: ['_config_dev.yml'] do
   ignore /^_site/
   watch /.*/
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,8 @@
+guard 'jekyll-plus', serve: true, port: 4000, config: ['_config_dev.yml'] do
+  ignore /^_site/
+  watch /.*/
+end
+
+guard 'livereload' do
+  watch /.*/
+end

--- a/README.md
+++ b/README.md
@@ -17,19 +17,16 @@ Check it with `ruby --version`
 
     ```bundle install```
 
-### Building and previewing
+### Local development: building and previewing
 
-For local development, use Jekyll to continually build the static files, and Rack to serve them:
+For local development, use Guard to run Jekyll on changes, and serve the files:
 
-`rackup`
+`guard`
 
 Then visit `http://127.0.0.1:4000`.
 
-#### Build for Local Development
-
-To have Jekyll watch over your files, and rebuild the static files when the sources change, use:
-
-```jekyll build --config _config_dev.yml -w```
+[Guard](https://github.com/guard/guard) will re-run Jekyll when its input files have changed, and trigger a browser reload using [guard-livereload](https://github.com/guard/guard-livereload) and [rake-livereload](https://github.com/johnbintz/rack-livereload).
+It also takes care of serving the files using [Rack](http://rack.github.io) via [guard-jekyll-plus](https://github.com/imathis/guard-jekyll-plus).
 
 #### Build for Production
 

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,9 @@
 #\ -w -p4000
 require 'sinatra/base'
 require 'rack/rewrite'
+require 'rack-livereload'
+
+use Rack::LiveReload
 
 use Rack::Rewrite do
   rewrite %r{/de(.*)}, '$1'


### PR DESCRIPTION
Using Guard as a one-stop solution: where we had `jekyll serve` before, it's now `guard`.

Guard will handle everything and even live-reload the browser.
