### PR TITLE
Add language switch to navigation -- on every page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -65,6 +65,12 @@
             {% endif %}
           {% endif %}
         {% endfor %}
+        <li class="divider"></li>
+          {% if page.is_default_language %}
+          <li><a href="{{ site.url }}{{ site.baseurl }}/en{{ page.url_no_language }}">English</a></li>
+	  {% else %}
+          <li><a href="{{ site.url }}{{ site.baseurl }}/de{{ page.url_no_language }}">German</a></li>
+	  {% endif %}
         {% comment %}   First loop finished 1   {% endcomment %}
       </ul>
 {% comment %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -66,12 +66,13 @@
           {% endif %}
         {% endfor %}
         <li class="divider"></li>
-          {% if page.is_default_language %}
-          <li><a href="{{ site.url }}{{ site.baseurl }}/en{{ page.url_no_language }}">English</a></li>
-	  {% else %}
-          <li><a href="{{ site.url }}{{ site.baseurl }}/de{{ page.url_no_language }}">German</a></li>
-	  {% endif %}
+        {% if page.is_default_language %}
+        <li><a href="{{ site.url }}{{ site.baseurl }}/en{{ page.url_no_language }}">English</a></li>
+	{% else %}
+        <li><a href="{{ site.url }}{{ site.baseurl }}/de{{ page.url_no_language }}">German</a></li>
+	{% endif %}
         {% comment %}   First loop finished 1   {% endcomment %}
+        <li class="divider"></li>
       </ul>
 {% comment %}
 

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -5,13 +5,6 @@ format: blog-index
 <section id="header-home">
   <div class="row t30">
     <div class="small-12 columns">
-      <nav class="right">
-        {% if page.is_default_language %}
-        <a class="button tiny" rel="alternate" href="/en" hreflang="en" lang="en">English</a>
-        {% else %}
-        <a class="button tiny" rel="alternate" href="/de" hreflang="de" lang="de">Deutsch</a>
-        {% endif %}
-      </nav>
       <article>
         <header>
           {% if page.subheadline %}<p class="subheadline">{{ page.subheadline }}</p>{% endif %}


### PR DESCRIPTION
I think this is more intuitive and convenient, maybe? If there's a link to `/de/hardware` somewhere (say, twitter), the user can just switch the language from the navigation menu and access `/en/hardware`. Dropped the language button from the start page, accordingly.
