### PR TITLE
Fix "(X only)" if it's not true, but the link is the same

### DIFF
--- a/_data/press.yml
+++ b/_data/press.yml
@@ -36,13 +36,13 @@
     en:
 - title:
     de: Internet Cafe by Refugee Emancipation
-    en:
+    en: Internet Cafe by Refugee Emancipation
   author:
   source: Grenzen_Weg!
   date: '2015-07-28'
   link:
     de: https://grenzenwegberlin.wordpress.com/2015/07/28/internet-cafe-by-refugee-emancipation/
-    en:
+    en: https://grenzenwegberlin.wordpress.com/2015/07/28/internet-cafe-by-refugee-emancipation/
   teaser:
     de: 'Viele der heutigen Migranten fliehen vor Gewaltherrschaft.
     Viele die in Deutschland landen, sitzen jahrelang fest in weit abgelegenen

--- a/_includes/press.html
+++ b/_includes/press.html
@@ -10,7 +10,7 @@
         {% endcomment %}
         {% if i.title.de %}
           <a href="{{ i.link.de }}" class="pub-link" target="_blank">{{ i.title.de }}</a>
-          {% if i.title.en %}(<a href="{{ i.link.en }}" class="pub-link" target="_blank">{{ i.title.en }}</a>){% endif %}
+          {% if i.title.en and (i.link.en != i.link.de)  %}(<a href="{{ i.link.en }}" class="pub-link" target="_blank">{{ i.title.en }}</a>){% endif %}
           <span class="pub-info">{%if i.author %}{{ i.author }}, {% endif %}{{ i.source }}</span>
         {% else %}
           <a href="{{ i.link.en }}" class="pub-link" target="_blank">{{ i.title.en }}</a> (nur Englisch)
@@ -25,7 +25,7 @@
         {% endcomment %}
         {% if i.title.en %}
           <a href="{{ i.link.en }}" class="pub-link" target="_blank">{{ i.title.en }}</a>
-          {% if i.title.de %}(<a href="{{ i.link.de }}" class="pub-link" target="_blank">{{ i.title.de }}</a>){% endif %}
+          {% if i.title.de and (i.link.de != i.link.en) %}(<a href="{{ i.link.de }}" class="pub-link" target="_blank">{{ i.title.de }}</a>){% endif %}
           <span class="pub-info">{%if i.author %}{{ i.author }}, {% endif %}{{ i.source }}</span>
         {% else %}
           <a href="{{ i.link.de }}" class="pub-link" target="_blank">{{ i.title.de }}</a> (German only)


### PR DESCRIPTION
With this, the "(German only)" disappears from bilingual Links (with the same URL).
There might be a better solution...
